### PR TITLE
Add Unit Test for BasketRemoveEmptyItems Method

### DIFF
--- a/tests\UnitTests\ApplicationCore\Entities\BasketTests\BasketRemoveEmptyItems.cs
+++ b/tests\UnitTests\ApplicationCore\Entities\BasketTests\BasketRemoveEmptyItems.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
+using Xunit;
+
+namespace Microsoft.eShopWeb.UnitTests.ApplicationCore.Entities.BasketTests;
+
+public class BasketRemoveEmptyItemsTests
+{
+    [Fact]
+    public async Task DoesNotRemovesNonEmptyBasketItems()
+    {
+        // Arrange
+        var basket = new Basket("TestBuyerId");
+        basket.AddItem(1, 10, 1);
+
+        // Act
+        basket.RemoveEmptyItems();
+
+        // Assert
+        Assert.Single(basket.Items);
+    }
+}


### PR DESCRIPTION
This pull request adds a unit test for the `BasketRemoveEmptyItems` method in the `Basket` class to ensure that items with quantities greater than 0 are not removed by this method. The test checks that after calling `RemoveEmptyItems` on a basket containing an item with quantity greater than 0, the item remains in the basket.