### PR TITLE
Add Unit Test for BasketRemoveEmptyItems Ensuring Non-Empty Items Remain

### DIFF
--- a/tests\UnitTests\ApplicationCore\Entities\BasketTests\BasketRemoveEmptyItems.cs
+++ b/tests\UnitTests\ApplicationCore\Entities\BasketTests\BasketRemoveEmptyItems.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
+using Xunit;
+
+namespace Microsoft.eShopWeb.UnitTests.ApplicationCore.Entities.BasketTests;
+
+public class BasketRemoveEmptyItems
+{
+    [Fact]
+    public async Task DoesNotRemovesNonEmptyBasketItems()
+    {
+        var basket = new Basket("buyerId");
+        basket.AddItem(1, 10, 1); // Add item with quantity greater than 0
+        basket.RemoveEmptyItems();
+
+        Assert.Single(basket.Items); // Assert that item is still in the basket
+    }
+}


### PR DESCRIPTION
Implements unit test `DoesNotRemovesNonEmptyBasketItems` to ensure that the `RemoveEmptyItems` method in `Basket` class does not remove items with quantity greater than 0.

This test adds an item to the basket with a quantity greater than 0 and then calls `RemoveEmptyItems` method. It asserts that the item is still present in the basket, ensuring the method's correctness for this scenario.