### PR TITLE
Add Unit Test for BasketRemoveEmptyItems Method

### DIFF
--- a/tests/UnitTests/ApplicationCore/Entities/BasketTests/BasketRemoveEmptyItems.cs
+++ b/tests/UnitTests/ApplicationCore/Entities/BasketTests/BasketRemoveEmptyItems.cs
@@ -18,4 +18,14 @@ public class BasketRemoveEmptyItems
 
         Assert.Equal(0, basket.Items.Count);
     }
+
+    [Fact]
+    public void DoesNotRemovesNonEmptyBasketItems()
+    {
+        var basket = new Basket("testBuyerId");
+        basket.AddItem(1, 10m, 1);
+        basket.RemoveEmptyItems();
+
+        Assert.Single(basket.Items);
+    }
 }


### PR DESCRIPTION
This PR adds a new unit test `DoesNotRemovesNonEmptyBasketItems` to ensure that the `RemoveEmptyItems` method in the `Basket` class does not remove items with a quantity greater than 0. This test is critical to ensuring the integrity of the basket's contents after cleanup operations.